### PR TITLE
Deprecation fix: bare `catch` statement

### DIFF
--- a/source/nbuff/buffer.d
+++ b/source/nbuff/buffer.d
@@ -70,7 +70,7 @@ debug(nbuff) @safe @nogc nothrow
                         {
                             //debug(nbuff)errorf("[%x] %s:%d Exception: %s", Thread.getThis().id(), file, line, e);
                         }
-                        catch
+                        catch(Exception e)
                         {
                         }
                     }();


### PR DESCRIPTION
Remove deprecation warning with recent D compilers.